### PR TITLE
allow building against gdal [3.0,3.2[

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.16', '1.15', '1.14' ]
-        gdal: [ 'release/3.2', 'release/3.3', 'master' ]
+        gdal: [ 'release/3.1', 'release/3.2', 'release/3.3', 'master' ]
     name: Go ${{ matrix.go }} + GDAL ${{ matrix.gdal }} test
     steps:
       - name: APT

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,6 +7,23 @@ on:
   pull_request:
 
 jobs:
+  ubuntu2004:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go: [ '1.16', '1.15', '1.14' ]
+    name: Go ${{ matrix.go }} + GDAL on ubuntu 20.04 test
+    steps:
+      - name: APT
+        run: sudo apt-get install gcc g++ libgeos-c1v5 libproj15 libsqlite3-0 pkgconf libjpeg-turbo8 libgdal-dev
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Coverage Tests
+        run: go test . -race
   build_gdal:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        gdal: [ 'release/3.2', 'release/3.3', 'master' ]
+        gdal: [ 'release/3.1', 'release/3.2', 'release/3.3', 'master' ]
     name: GDAL ${{ matrix.gdal }} build
     steps:
       - name: Checkout

--- a/godal.cpp
+++ b/godal.cpp
@@ -1118,7 +1118,9 @@ namespace cpl
 							   ) override;
 
 		int Stat(const char *pszFilename, VSIStatBufL *pStatBuf, int nFlags) override;
+#if GDAL_VERSION_NUM >= 3020000
         char **SiblingFiles(const char *pszFilename) override;
+#endif
         int HasOptimizedReadMultiRange(const char *pszPath) override;
     };
 
@@ -1403,10 +1405,12 @@ namespace cpl
         return TRUE;
     }
 
+#if GDAL_VERSION_NUM >= 3020000
     char **VSIGoFilesystemHandler::SiblingFiles(const char *pszFilename)
     {
         return (char **)calloc(1, sizeof(char *));
     }
+#endif
 
 } // namespace cpl
 

--- a/godal.h
+++ b/godal.h
@@ -22,8 +22,8 @@
 #include "cpl_port.h"
 #include <gdal_frmts.h>
 
-#if GDAL_VERSION_NUM < 3020000
-	#error "this code is only compatible with gdal version >= 3.2"
+#if GDAL_VERSION_NUM < 3000000
+	#error "this code is only compatible with gdal version >= 3.0"
 #endif
 
 #ifdef __cplusplus

--- a/godal_test.go
+++ b/godal_test.go
@@ -509,7 +509,7 @@ func TestStructure(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	AssertMinVersion(3, 2, 0)
+	AssertMinVersion(3, 0, 0)
 	assert.Panics(t, func() { AssertMinVersion(99, 99, 99) })
 }
 


### PR DESCRIPTION
since #22 godal ignores sibling files by default without resorting to the (non-functional) VSISiblingFiles callback introduced in gdal 3.2. We can thus support gdal >= 3.0 now.