### PR TITLE
Cleanup VSI adapter handling

### DIFF
--- a/cogify/cogify-main.go
+++ b/cogify/cogify-main.go
@@ -81,7 +81,7 @@ var cogCommand = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("osio.newadapter: %w", err)
 			}
-			err = godal.RegisterVSIAdapter("gs://", gsa)
+			err = godal.RegisterVSIHandler("gs://", gsa)
 			if err != nil {
 				return fmt.Errorf("godal.registervsi: %w", err)
 			}

--- a/gdalplugin/gcs_adapter.go
+++ b/gdalplugin/gcs_adapter.go
@@ -44,12 +44,12 @@ func splitRanges() bool {
 	}
 }
 
+// GDALRegister_gcs is called by gdal when loading this so. It is not meant to be used directly from go.
+//
 //export GDALRegister_gcs
 func GDALRegister_gcs() {
 	ctx = context.Background()
-	opts := []osio.AdapterOption{
-		osio.SplitRanges(splitRanges()),
-	}
+	opts := []osio.AdapterOption{}
 	if bs := blockSize(); bs != "" {
 		opts = append(opts, osio.BlockSize(bs))
 	}
@@ -66,7 +66,7 @@ func GDALRegister_gcs() {
 		log.Printf("osio.newadapter() failed: %v", err)
 		return
 	}
-	err = godal.RegisterVSIAdapter("gs://", gcsa)
+	err = godal.RegisterVSIHandler("gs://", gcsa)
 	if err != nil {
 		log.Printf("godal.registervsiadapter() failed: %v", err)
 		return


### PR DESCRIPTION
This is a breaking change. RegisterVSIHandler now requires a
KeySizerReaderAt. RegisterVSIAdapter is removed.

To update client code: s/RegisterVSIAdapter/RegisterVSIHandler/
