### PR TITLE
Add getters for scale and offset

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -130,6 +130,7 @@ func ErrLogger(fn ErrorHandler) interface {
 	SetGeometryOption
 	SetFieldValueOption
 	SetNoDataOption
+	SetScaleOffsetOption
 	SetGeoTransformOption
 	SetProjectionOption
 	SetSpatialRefOption
@@ -300,6 +301,9 @@ func (ec errorCallback) setSetProjectionOpt(o *setProjectionOpts) {
 }
 func (ec errorCallback) setSetNoDataOpt(ndo *setNodataOpts) {
 	ndo.errorHandler = ec.fn
+}
+func (ec errorCallback) setSetScaleOffsetOpt(soo *setScaleOffsetOpts) {
+	soo.errorHandler = ec.fn
 }
 func (ec errorCallback) setSetSpatialRefOpt(ndo *setSpatialRefOpts) {
 	ndo.errorHandler = ec.fn

--- a/godal.h
+++ b/godal.h
@@ -56,6 +56,8 @@ extern "C" {
 	void godalSetRasterNoDataValue(cctx *ctx, GDALRasterBandH bnd, double nd);
 	void godalSetDatasetNoDataValue(cctx *ctx, GDALDatasetH bnd, double nd);
 	void godalDeleteRasterNoDataValue(cctx *ctx, GDALRasterBandH bnd);
+	void godalSetRasterScaleOffset(cctx *ctx, GDALRasterBandH bnd, double scale, double offset);
+	void godalSetDatasetScaleOffset(cctx *ctx, GDALDatasetH bnd, double scale, double offset);
 	void godalSetRasterColorInterpretation(cctx *ctx, GDALRasterBandH bnd, GDALColorInterp ci);
 	GDALRasterBandH godalCreateMaskBand(cctx *ctx, GDALRasterBandH bnd, int flags);
 	GDALRasterBandH godalCreateDatasetMaskBand(cctx *ctx, GDALDatasetH ds, int flags);
@@ -80,8 +82,8 @@ extern "C" {
 	void godalBuildOverviews(cctx *ctx, GDALDatasetH ds, const char *resampling, int nLevels, int *levels, int nBands, int *bands);
 	void godalClearOverviews(cctx *ctx, GDALDatasetH ds);
 
-	void godalDatasetStructure(GDALDatasetH ds, int *sx, int *sy, int *bsx, int *bsy, int *bandCount, int *dtype);
-	void godalBandStructure(GDALRasterBandH bnd, int *sx, int *sy, int *bsx, int *bsy, int *dtype);
+	void godalDatasetStructure(GDALDatasetH ds, int *sx, int *sy, int *bsx, int *bsy, double *scale, double *offset, int *bandCount, int *dtype);
+	void godalBandStructure(GDALRasterBandH bnd, int *sx, int *sy, int *bsx, int *bsy, double *scale, double *offset, int *dtype);
 	void godalDatasetRasterIO(cctx *ctx, GDALDatasetH ds, GDALRWFlag rw, int nDSXOff, int nDSYOff, int nDSXSize, int nDSYSize, void *pBuffer,
 		int nBXSize, int nBYSize, GDALDataType eBDataType, int nBandCount, int *panBandCount,
 		int nPixelSpace, int nLineSpace, int nBandSpace, GDALRIOResampleAlg alg);

--- a/godal_test.go
+++ b/godal_test.go
@@ -485,6 +485,8 @@ func TestBands(t *testing.T) {
 	bst := bands[0].Structure()
 	assert.Equal(t, 256, bst.BlockSizeX)
 	assert.Equal(t, 256, bst.BlockSizeY)
+	assert.Equal(t, 1.0, bst.Scale)
+	assert.Equal(t, 0.0, bst.Offset)
 	dt := bands[1].Structure().DataType
 	assert.Equal(t, Byte, dt)
 	assert.Equal(t, "Byte", dt.String())
@@ -518,6 +520,34 @@ func TestNoData(t *testing.T) {
 	nd, ok = bands[0].NoData()
 	assert.Equal(t, 101.0, nd)
 	assert.Equal(t, true, ok)
+}
+
+func TestSetScale(t *testing.T) {
+	ds, err := Create(Memory, "ffff", 2, Byte, 20, 20)
+	require.NoError(t, err)
+	defer ds.Close()
+	bands := ds.Bands()
+	err = bands[1].SetScaleOffset(100, 100)
+	assert.NoError(t, err)
+	ehc := eh()
+	err = bands[1].SetScaleOffset(100, 100, ErrLogger(ehc.ErrorHandler))
+	assert.NoError(t, err)
+	st := bands[1].Structure()
+	assert.Equal(t, 100.0, st.Scale)
+	assert.Equal(t, 100.0, st.Offset)
+	err = bands[1].ClearScaleOffset()
+	assert.NoError(t, err)
+	ehc = eh()
+	err = bands[1].ClearScaleOffset(ErrLogger(ehc.ErrorHandler))
+	assert.NoError(t, err)
+	st = bands[1].Structure()
+	assert.Equal(t, 1.0, st.Scale)
+	assert.Equal(t, 0.0, st.Offset)
+	err = ds.SetScaleOffset(101, 101)
+	assert.NoError(t, err)
+	st = bands[0].Structure()
+	assert.Equal(t, 101.0, st.Scale)
+	assert.Equal(t, 101.0, st.Offset)
 }
 
 func TestStructure(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -72,6 +72,18 @@ type setNodataOpts struct {
 	errorHandler ErrorHandler
 }
 
+//SetScaleOffsetOption is an option that can be passed to Band.SetScaleOffset(),
+//Band.ClearScaleOffset(), Dataset.SetScaleOffset()
+//
+// Available SetScaleOffsetOptions are:
+//  - ErrLogger
+type SetScaleOffsetOption interface {
+	setSetScaleOffsetOpt(so *setScaleOffsetOpts)
+}
+type setScaleOffsetOpts struct {
+	errorHandler ErrorHandler
+}
+
 //SetColorInterpOption is an option that can be passed to Band.SetColorInterpretation()
 //
 // Available SetColorInterpOption are:

--- a/structure.go
+++ b/structure.go
@@ -67,6 +67,7 @@ func BlockIterator(sizeX, sizeY int, blockSizeX, blockSizeY int) Block {
 type BandStructure struct {
 	SizeX, SizeY           int
 	BlockSizeX, BlockSizeY int
+	Scale, Offset          float64
 	DataType               DataType
 }
 


### PR DESCRIPTION
We use scale and offset meta data to pack float into an integer type. Therefore, I would really like to merge this pull request.