### PR TITLE
add support for GDALRegisterPlugins() (3.8+ only)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -153,6 +153,7 @@ func ErrLogger(fn ErrorHandler) interface {
 	GridOption
 	NearblackOption
 	SetGCPsOption
+	RegisterPluginOption
 } {
 	return errorCallback{fn}
 }
@@ -374,6 +375,9 @@ func (ec errorCallback) setNearblackOpt(o *nearBlackOpts) {
 	o.errorHandler = ec.fn
 }
 func (ec errorCallback) setSetGCPsOpt(o *setGCPsOpts) {
+	o.errorHandler = ec.fn
+}
+func (ec errorCallback) setRegisterPluginOpt(o *registerPluginOpts) {
 	o.errorHandler = ec.fn
 }
 

--- a/godal.cpp
+++ b/godal.cpp
@@ -200,6 +200,19 @@ void godalRegisterPlugins(){
 #endif
 }
 
+void godalRegisterPlugin(cctx *ctx, const char *name){
+  godalWrap(ctx);
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 8, 0)
+  CPLErr ret = GDALRegisterPlugin(name);
+  if (ret != 0) {
+	  forceCPLError(ctx, ret);
+  }
+#else
+	CPLError(CE_Failure, CPLE_NotSupported, "GDALRegisterPlugin is only supported in GDAL version >= 3.8");
+#endif
+	godalUnwrap();
+}
+
 GDALDatasetH godalCreate(cctx *ctx, GDALDriverH drv, const char* name, int width, int height, int nbands,
 							GDALDataType dtype, char **options) {
 	godalWrap(ctx);

--- a/godal.cpp
+++ b/godal.cpp
@@ -194,6 +194,12 @@ int godalRegisterDriver(const char *fnname) {
 	return -1;
 }
 
+void godalRegisterPlugins(){
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 8, 0)
+  GDALRegisterPlugins();
+#endif
+}
+
 GDALDatasetH godalCreate(cctx *ctx, GDALDriverH drv, const char* name, int width, int height, int nbands,
 							GDALDataType dtype, char **options) {
 	godalWrap(ctx);

--- a/godal.go
+++ b/godal.go
@@ -903,7 +903,7 @@ func (ds *Dataset) SetNoData(nd float64, opts ...SetNoDataOption) error {
 	return cgc.close()
 }
 
-// SetScale sets the band's scale and offset
+// SetScaleOffset sets the band's scale and offset
 func (ds *Dataset) SetScaleOffset(scale, offset float64, opts ...SetScaleOffsetOption) error {
 	setterOpts := &setScaleOffsetOpts{}
 	for _, opt := range opts {

--- a/godal.go
+++ b/godal.go
@@ -903,7 +903,7 @@ func (ds *Dataset) SetNoData(nd float64, opts ...SetNoDataOption) error {
 	return cgc.close()
 }
 
-// SetScaleOffset sets the band's scale and offset
+// SetScale sets the band's scale and offset
 func (ds *Dataset) SetScaleOffset(scale, offset float64, opts ...SetScaleOffsetOption) error {
 	setterOpts := &setScaleOffsetOpts{}
 	for _, opt := range opts {
@@ -1263,6 +1263,10 @@ func (ds *Dataset) IO(rw IOOperation, srcX, srcY int, buffer interface{}, bufWid
 //   - godal.RegisterVector(godal.Shapefile)
 func RegisterAll() {
 	C.GDALAllRegister()
+}
+
+func GDALRegisterPlugins() {
+	C.godalRegisterPlugins()
 }
 
 // RegisterRaster registers a raster driver by name.

--- a/godal.go
+++ b/godal.go
@@ -1265,8 +1265,20 @@ func RegisterAll() {
 	C.GDALAllRegister()
 }
 
-func GDALRegisterPlugins() {
+func RegisterPlugins() {
 	C.godalRegisterPlugins()
+}
+
+func RegisterPlugin(name string, opts ...RegisterPluginOption) error {
+	ro := registerPluginOpts{}
+	for _, o := range opts {
+		o.setRegisterPluginOpt(&ro)
+	}
+	cgc := createCGOContext(nil, ro.errorHandler)
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	C.godalRegisterPlugin(cgc.cPointer(), cname)
+	return cgc.close()
 }
 
 // RegisterRaster registers a raster driver by name.

--- a/godal.h
+++ b/godal.h
@@ -47,6 +47,7 @@ extern "C" {
 
 	void godalClose(cctx *ctx, GDALDatasetH ds);
 	int godalRegisterDriver(const char *funcname);
+	void godalRegisterPlugins();
 	void godalRasterSize(GDALDatasetH ds, int *xsize, int *ysize);
 
 	//returns a null terminated list of bands. the caller must free the returned list

--- a/godal.h
+++ b/godal.h
@@ -48,6 +48,7 @@ extern "C" {
 	void godalClose(cctx *ctx, GDALDatasetH ds);
 	int godalRegisterDriver(const char *funcname);
 	void godalRegisterPlugins();
+	void godalRegisterPlugin(cctx *ctx, const char *name);
 	void godalRasterSize(GDALDatasetH ds, int *xsize, int *ysize);
 
 	//returns a null terminated list of bands. the caller must free the returned list

--- a/godal_test.go
+++ b/godal_test.go
@@ -264,6 +264,24 @@ func TestRegisterDrivers(t *testing.T) {
 	assert.True(t, ok)
 	_, ok = VectorDriver("Mapinfo File")
 	assert.True(t, ok)
+
+	runtimeVersion := Version()
+	supported := runtimeVersion.Major() > 3 ||
+		(runtimeVersion.Major() == 3 && runtimeVersion.Minor() >= 8)
+
+	ehc := eh()
+	err = RegisterPlugin("foobarsljgsa", ErrLogger(ehc.ErrorHandler))
+	assert.Error(t, err)
+	if !supported {
+		assert.Contains(t, err.Error(), "GDALRegisterPlugin is only supported")
+	}
+	err = RegisterPlugin("foobarsljgsa")
+	assert.Error(t, err)
+	err = RegisterPlugin("dehazer")
+	assert.NoError(t, err)
+
+	//smoke test for RegisterPlugins
+	RegisterPlugins()
 }
 
 func TestVectorCreate(t *testing.T) {

--- a/godal_test.go
+++ b/godal_test.go
@@ -277,8 +277,6 @@ func TestRegisterDrivers(t *testing.T) {
 	}
 	err = RegisterPlugin("foobarsljgsa")
 	assert.Error(t, err)
-	err = RegisterPlugin("dehazer")
-	assert.NoError(t, err)
 
 	//smoke test for RegisterPlugins
 	RegisterPlugins()

--- a/options.go
+++ b/options.go
@@ -1297,6 +1297,15 @@ func (gsr gcpSpatialRefOpt) setSetGCPsOpt(sgOpt *setGCPsOpts) {
 	sgOpt.sr = gsr.sr
 }
 
+type registerPluginOpts struct {
+	errorHandler ErrorHandler
+}
+
+// RegisterPluginOption is an option that can be passed to RegisterPlugin()
+type RegisterPluginOption interface {
+	setRegisterPluginOpt(rpOpt *registerPluginOpts)
+}
+
 // RasterizeGeometryOption is an option that can be passed tp Dataset.RasterizeGeometry()
 type RasterizeGeometryOption interface {
 	setRasterizeGeometryOpt(o *rasterizeGeometryOpts)


### PR DESCRIPTION
requires OSGeo/gdal#8447 and OSGeo/gdal#8511 to be usable