### PR TITLE
HasVSIHandler to test if a VSIHandler is registered for a given prefix

### DIFF
--- a/godal.go
+++ b/godal.go
@@ -3898,6 +3898,15 @@ func RegisterVSIHandler(prefix string, handler KeySizerReaderAt, opts ...VSIHand
 	return nil
 }
 
+// HasVSIHandler returns true if a VSIHandler is registered for this prefix
+func HasVSIHandler(prefix string) bool {
+	if handlers == nil {
+		return false
+	}
+	_, ok := handlers[prefix]
+	return ok
+}
+
 // BuildVRT runs the GDALBuildVRT function and creates a VRT dataset from a list of datasets
 func BuildVRT(dstVRTName string, sourceDatasets []string, switches []string, opts ...BuildVRTOption) (*Dataset, error) {
 	bvo := buildVRTOpts{}

--- a/godal.go
+++ b/godal.go
@@ -3900,11 +3900,7 @@ func RegisterVSIHandler(prefix string, handler KeySizerReaderAt, opts ...VSIHand
 
 // HasVSIHandler returns true if a VSIHandler is registered for this prefix
 func HasVSIHandler(prefix string) bool {
-	if handlers == nil {
-		return false
-	}
-	_, ok := handlers[prefix]
-	return ok
+	return handlers != nil && handlers[prefix].KeySizerReaderAt != nil
 }
 
 // BuildVRT runs the GDALBuildVRT function and creates a VRT dataset from a list of datasets

--- a/godal_test.go
+++ b/godal_test.go
@@ -3459,17 +3459,31 @@ func (mvp mvpHandler) ReadAtMulti(k string, buf [][]byte, off []int64) ([]int, e
 	}
 	return b.(KeyMultiReader).ReadAtMulti(k, buf, off)
 }
+func TestHasVSIHandler(t *testing.T) { // stripPrefix false
+	assert.False(t, HasVSIHandler("unregistered_prefix://"))
+
+	vpa := vpHandler{datas: make(map[string]KeySizerReaderAt)}
+	err := RegisterVSIHandler("registered_prefix://", vpa, VSIHandlerStripPrefix(false))
+	assert.NoError(t, err)
+	assert.True(t, HasVSIHandler("registered_prefix://"))
+
+	// nil handler
+	err = RegisterVSIHandler("nil_prefix://", nil)
+	assert.NoError(t, err)
+	assert.False(t, HasVSIHandler("nil_prefix://"))
+
+	// unregistered_prefix
+	assert.False(t, HasVSIHandler("unregistered_prefix://"))
+}
 
 func TestVSIPrefix(t *testing.T) {
 	tifdat, _ := ioutil.ReadFile("testdata/test.tif")
 
-	assert.False(t, HasVSIHandler("prefix://"))
 	// stripPrefix false
 	vpa := vpHandler{datas: make(map[string]KeySizerReaderAt)}
 	vpa.datas["prefix://test.tif"] = mbufHandler{tifdat}
 	err := RegisterVSIHandler("prefix://", vpa, VSIHandlerStripPrefix(false))
 	assert.NoError(t, err)
-	assert.True(t, HasVSIHandler("prefix://"))
 
 	ds, err := Open("prefix://test.tif")
 	if err != nil {

--- a/godal_test.go
+++ b/godal_test.go
@@ -3463,11 +3463,13 @@ func (mvp mvpHandler) ReadAtMulti(k string, buf [][]byte, off []int64) ([]int, e
 func TestVSIPrefix(t *testing.T) {
 	tifdat, _ := ioutil.ReadFile("testdata/test.tif")
 
+	assert.False(t, HasVSIHandler("prefix://"))
 	// stripPrefix false
 	vpa := vpHandler{datas: make(map[string]KeySizerReaderAt)}
 	vpa.datas["prefix://test.tif"] = mbufHandler{tifdat}
 	err := RegisterVSIHandler("prefix://", vpa, VSIHandlerStripPrefix(false))
 	assert.NoError(t, err)
+	assert.True(t, HasVSIHandler("prefix://"))
 
 	ds, err := Open("prefix://test.tif")
 	if err != nil {


### PR DESCRIPTION
Instead of testing the error of "RegisterVSIHandler()"