### PR TITLE
Replace sprintf with snprintf

### DIFF
--- a/godal.cpp
+++ b/godal.cpp
@@ -172,7 +172,7 @@ typedef void (*fn_def)(void);
 
 int _go_registerDriver(const char *driver, const char *prefix) {
 	char *fnname = (char*)calloc(1,strlen(driver)+strlen(prefix)+1);
-	sprintf(fnname,"%s%s",prefix,driver);
+	snprintf(fnname, sizeof(fnname), "%s%s", prefix, driver);
 	void *fcn = dlsym(RTLD_DEFAULT,fnname);
 	free(fnname);
 	if (fcn != nullptr) {


### PR DESCRIPTION
warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]