### PR TITLE
Adding raster thread-safe flag

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -138,8 +138,9 @@ func Drivers(drivers ...string) interface {
 } {
 	return driversOpt{drivers}
 }
-func (do driversOpt) setOpenOpt(oo *openOpts) {
+func (do driversOpt) setOpenOpt(oo *openOpts) error {
 	oo.drivers = append(oo.drivers, do.drivers...)
+	return nil
 }
 
 type driverOpenOption struct {
@@ -154,8 +155,9 @@ func DriverOpenOption(keyval ...string) interface {
 } {
 	return driverOpenOption{keyval}
 }
-func (doo driverOpenOption) setOpenOpt(oo *openOpts) {
+func (doo driverOpenOption) setOpenOpt(oo *openOpts) error {
 	oo.options = append(oo.options, doo.oo...)
+	return nil
 }
 func (doo driverOpenOption) setBuildVRTOpt(bvo *buildVRTOpts) {
 	bvo.openOptions = append(bvo.openOptions, doo.oo...)

--- a/errors.go
+++ b/errors.go
@@ -290,8 +290,9 @@ func (ec errorCallback) setNewFeatureOpt(o *newFeatureOpts) {
 func (ec errorCallback) setNewGeometryOpt(o *newGeometryOpts) {
 	o.errorHandler = ec.fn
 }
-func (ec errorCallback) setOpenOpt(oo *openOpts) {
+func (ec errorCallback) setOpenOpt(oo *openOpts) error {
 	oo.errorHandler = ec.fn
+	return nil
 }
 func (ec errorCallback) setPolygonizeOpt(o *polygonizeOpts) {
 	o.errorHandler = ec.fn

--- a/godal.go
+++ b/godal.go
@@ -1958,7 +1958,7 @@ func Update() interface {
 
 func (openUpdateOpt) setOpenOpt(oo *openOpts) error {
 	//unset readonly
-	oo.flags = oo.flags &^ C.GDAL_OF_READONLY //actually a noop as OF_READONLY is 0
+	oo.flags = oo.flags &^ C.GDAL_OF_READONLY //actually a noop as GDAL_OF_READONLY is 0
 	oo.flags |= C.GDAL_OF_UPDATE
 	return nil
 }

--- a/godal.go
+++ b/godal.go
@@ -1995,6 +1995,8 @@ type threadSafeOpt struct{}
 // ThreadSafe adds capability to open, or obtain, a thread-safe dataset from any
 // dataset, but only for raster read-only use cases.  Should be used with
 // RasterOnly option. (GDAL>=3.10.0)
+//
+// If used before supported GDAL version, flag will be a noop.
 func ThreadSafe() interface {
 	OpenOption
 } {

--- a/godal.go
+++ b/godal.go
@@ -2000,6 +2000,7 @@ func ThreadSafe() interface {
 } {
 	return threadSafeOpt{}
 }
+
 func (threadSafeOpt) setOpenOpt(oo *openOpts) {
 	oo.flags |= C.GDAL_OF_THREAD_SAFE
 }

--- a/godal.go
+++ b/godal.go
@@ -1990,6 +1990,20 @@ func (rasterOnlyOpt) setOpenOpt(oo *openOpts) {
 	oo.flags |= C.GDAL_OF_RASTER
 }
 
+type threadSafeOpt struct{}
+
+// ThreadSafe adds capability to open, or obtain, a thread-safe dataset from any
+// dataset, but only for raster read-only use cases.  Should be used with
+// RasterOnly option. (GDAL>=3.10.0)
+func ThreadSafe() interface {
+	OpenOption
+} {
+	return threadSafeOpt{}
+}
+func (threadSafeOpt) setOpenOpt(oo *openOpts) {
+	oo.flags |= C.GDAL_OF_THREAD_SAFE
+}
+
 // SpatialRef is a wrapper around OGRSpatialReferenceH
 type SpatialRef struct {
 	handle  C.OGRSpatialReferenceH

--- a/godal.go
+++ b/godal.go
@@ -1519,9 +1519,18 @@ func Open(name string, options ...OpenOption) (*Dataset, error) {
 		flags:        C.GDAL_OF_READONLY | C.GDAL_OF_VERBOSE_ERROR,
 		siblingFiles: []string{filepath.Base(name)},
 	}
+
+	var optErr error
 	for _, opt := range options {
-		opt.setOpenOpt(&oopts)
+		if err := opt.setOpenOpt(&oopts); err != nil {
+			optErr = errors.Join(optErr, err)
+		}
 	}
+
+	if optErr != nil {
+		return nil, fmt.Errorf("error applying options: %w", optErr)
+	}
+
 	csiblings := sliceToCStringArray(oopts.siblingFiles)
 	coopts := sliceToCStringArray(oopts.options)
 	cdrivers := sliceToCStringArray(oopts.drivers)
@@ -1947,10 +1956,11 @@ func Update() interface {
 	return openUpdateOpt{}
 }
 
-func (openUpdateOpt) setOpenOpt(oo *openOpts) {
+func (openUpdateOpt) setOpenOpt(oo *openOpts) error {
 	//unset readonly
 	oo.flags = oo.flags &^ C.GDAL_OF_READONLY //actually a noop as OF_READONLY is 0
 	oo.flags |= C.GDAL_OF_UPDATE
+	return nil
 }
 
 type openSharedOpt struct{}
@@ -1962,8 +1972,9 @@ func Shared() interface {
 	return openSharedOpt{}
 }
 
-func (openSharedOpt) setOpenOpt(oo *openOpts) {
+func (openSharedOpt) setOpenOpt(oo *openOpts) error {
 	oo.flags |= C.GDAL_OF_SHARED
+	return nil
 }
 
 type vectorOnlyOpt struct{}
@@ -1974,8 +1985,9 @@ func VectorOnly() interface {
 } {
 	return vectorOnlyOpt{}
 }
-func (vectorOnlyOpt) setOpenOpt(oo *openOpts) {
+func (vectorOnlyOpt) setOpenOpt(oo *openOpts) error {
 	oo.flags |= C.GDAL_OF_VECTOR
+	return nil
 }
 
 type rasterOnlyOpt struct{}
@@ -1986,8 +1998,9 @@ func RasterOnly() interface {
 } {
 	return rasterOnlyOpt{}
 }
-func (rasterOnlyOpt) setOpenOpt(oo *openOpts) {
+func (rasterOnlyOpt) setOpenOpt(oo *openOpts) error {
 	oo.flags |= C.GDAL_OF_RASTER
+	return nil
 }
 
 type threadSafeOpt struct{}
@@ -1995,16 +2008,21 @@ type threadSafeOpt struct{}
 // ThreadSafe adds capability to open, or obtain, a thread-safe dataset from any
 // dataset, but only for raster read-only use cases.  Should be used with
 // RasterOnly option. (GDAL>=3.10.0)
-//
-// If used before supported GDAL version, flag will be a noop.
 func ThreadSafe() interface {
 	OpenOption
 } {
 	return threadSafeOpt{}
 }
 
-func (threadSafeOpt) setOpenOpt(oo *openOpts) {
+var ErrUnsupportedThreadSafe = errors.New("thread-safe flag unsupported below gdal version 3.10")
+
+func (threadSafeOpt) setOpenOpt(oo *openOpts) error {
+	if !CheckMinVersion(3, 10, 0) {
+		return ErrUnsupportedThreadSafe
+	}
+
 	oo.flags |= C.GDAL_OF_THREAD_SAFE
+	return nil
 }
 
 // SpatialRef is a wrapper around OGRSpatialReferenceH

--- a/godal.h
+++ b/godal.h
@@ -33,6 +33,12 @@ typedef enum {
 } FutureGDALDataType;
 #endif
 
+#ifndef GDAL_OF_THREAD_SAFE
+  /* GDAL < 3.10, no thread-safe flag */
+  /* will be a noop */
+  #define GDAL_OF_THREAD_SAFE 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/godal.h
+++ b/godal.h
@@ -35,7 +35,7 @@ typedef enum {
 
 #ifndef GDAL_OF_THREAD_SAFE
   /* GDAL < 3.10, no thread-safe flag */
-  /* will be a noop */
+  /* will be a noop when used in a bitwise OR */
   #define GDAL_OF_THREAD_SAFE 0
 #endif
 

--- a/godal.h
+++ b/godal.h
@@ -33,10 +33,9 @@ typedef enum {
 } FutureGDALDataType;
 #endif
 
-#ifndef GDAL_OF_THREAD_SAFE
-  /* GDAL < 3.10, no thread-safe flag */
-  /* will be a noop when used in a bitwise OR */
-  #define GDAL_OF_THREAD_SAFE 0
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3, 10, 0)
+	/* GDAL < 3.10, no thread-safe flag */
+	#define GDAL_OF_THREAD_SAFE 0
 #endif
 
 #ifdef __cplusplus

--- a/godal_test.go
+++ b/godal_test.go
@@ -1271,15 +1271,7 @@ func TestOpen(t *testing.T) {
 	if err == nil {
 		t.Error("error not raised")
 	}
-	ds, err := Open("testdata/test.tif", RasterOnly(), ThreadSafe())
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ds.Close()
-	if err != nil {
-		t.Error(err)
-	}
-	ds, err = Open("testdata/test.tif")
+	ds, err := Open("testdata/test.tif")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1300,6 +1292,17 @@ func TestOpen(t *testing.T) {
 	_, err = Open("godal.cpp")
 	if err == nil {
 		t.Error("error not caught")
+	}
+}
+
+func TestOpenThreadsafe(t *testing.T) {
+	ds, err := Open("testdata/test.tif", RasterOnly(), ThreadSafe())
+
+	if CheckMinVersion(3, 10, 0) {
+		require.NoError(t, err)
+		assert.NoError(t, ds.Close())
+	} else {
+		assert.ErrorIs(t, err, ErrUnsupportedThreadSafe)
 	}
 }
 

--- a/godal_test.go
+++ b/godal_test.go
@@ -1271,6 +1271,10 @@ func TestOpen(t *testing.T) {
 	if err == nil {
 		t.Error("error not raised")
 	}
+	_, err = Open("testdata/test.tif", RasterOnly(), ThreadSafe())
+	if err != nil {
+		t.Fatal(err)
+	}
 	ds, err := Open("testdata/test.tif")
 	if err != nil {
 		t.Fatal(err)

--- a/godal_test.go
+++ b/godal_test.go
@@ -1271,11 +1271,15 @@ func TestOpen(t *testing.T) {
 	if err == nil {
 		t.Error("error not raised")
 	}
-	_, err = Open("testdata/test.tif", RasterOnly(), ThreadSafe())
+	ds, err := Open("testdata/test.tif", RasterOnly(), ThreadSafe())
 	if err != nil {
 		t.Fatal(err)
 	}
-	ds, err := Open("testdata/test.tif")
+	err = ds.Close()
+	if err != nil {
+		t.Error(err)
+	}
+	ds, err = Open("testdata/test.tif")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/options.go
+++ b/options.go
@@ -369,7 +369,7 @@ type openOpts struct {
 //   - RasterOnly
 //   - VectorOnly
 type OpenOption interface {
-	setOpenOpt(oo *openOpts)
+	setOpenOpt(oo *openOpts) error
 }
 
 type closeOpts struct {
@@ -647,12 +647,14 @@ func SiblingFiles(files ...string) interface {
 } {
 	return siblingFilesOpt{files}
 }
-func (sf siblingFilesOpt) setOpenOpt(oo *openOpts) {
+
+func (sf siblingFilesOpt) setOpenOpt(oo *openOpts) error {
 	if len(sf.files) > 0 {
 		oo.siblingFiles = append(oo.siblingFiles, sf.files...)
 	} else {
 		oo.siblingFiles = nil
 	}
+	return nil
 }
 
 type setDescriptionOpts struct {
@@ -973,8 +975,9 @@ func (co configOpt) setDatasetCreateMaskOpt(dcm *dsCreateMaskOpts) {
 func (co configOpt) setBandCreateMaskOpt(bcm *bandCreateMaskOpts) {
 	bcm.config = append(bcm.config, co.config...)
 }
-func (co configOpt) setOpenOpt(oo *openOpts) {
+func (co configOpt) setOpenOpt(oo *openOpts) error {
 	oo.config = append(oo.config, co.config...)
+	return nil
 }
 func (co configOpt) setRasterizeOpt(oo *rasterizeOpts) {
 	oo.config = append(oo.config, co.config...)

--- a/options.go
+++ b/options.go
@@ -367,6 +367,7 @@ type openOpts struct {
 //   - Update
 //   - DriverOpenOption
 //   - RasterOnly
+//   - ThreadSafe
 //   - VectorOnly
 type OpenOption interface {
 	setOpenOpt(oo *openOpts) error


### PR DESCRIPTION
## Description

Adds threadsafe flag for reading raster datasets.

https://gdal.org/en/stable/user/multithreading.html

> Added in version 3.10.
> 
> [RFC 101: Raster dataset read-only thread-safety](https://gdal.org/en/stable/development/rfc/rfc101_raster_dataset_threadsafety.html#rfc-101) adds a new capability to open, or obtain, a thread-safe dataset from any dataset, but only for raster read-only use cases.
>
> At open time, this can be done by passing GDAL_OF_RASTER | GDAL_OF_THREAD_SAFE to [GDALOpenEx()](https://gdal.org/en/stable/api/raster_c_api.html#_CPPv410GDALOpenExPKcjPPCKcPPCKcPPCKc) / [GDALDataset::Open()](https://gdal.org/en/stable/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset4OpenEPKcjPPCKcPPCKcPPCKc).
